### PR TITLE
Use circleci/aws-eks as orb name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orb_promotion_filters: &orb_promotion_filters
     only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
 
 orbs:
-  aws-eks: sandbox/aws-eks@dev:alpha
+  aws-eks: circleci/aws-eks@dev:alpha
   cli: circleci/circleci-cli@0.1.2
   orb-tools: circleci/orb-tools@7.3.0
   queue: eddiewebb/queue@1.1.2
@@ -439,7 +439,7 @@ workflows:
           requires:
             - orb-tools/pack
       - orb-tools/publish-dev:
-          orb-name: sandbox/aws-eks
+          orb-name: circleci/aws-eks
           requires:
             - queue/block_workflow
       - orb-tools/trigger-integration-workflow:
@@ -663,7 +663,7 @@ workflows:
             - pre-orb-promotion-check
           filters: *orb_promotion_filters
       - promote-orb-into-production:
-          orb-name: sandbox/aws-eks
+          orb-name: circleci/aws-eks
           orb-ref: dev:${CIRCLE_SHA1:0:7}
           requires:
             - hold-for-approval


### PR DESCRIPTION
Note: Promotion of dev orb to production will be done separately, via the manual, git-tag-triggered workflow "production-orb-publishing". This would need the CIRCLE_TOKEN env var as set in https://circleci.com/gh/CircleCI-Public/aws-eks-orb/edit#env-vars to be updated to the value of a token associated with an org owner

