### PR TITLE
Use CIRCLE_TOKEN defined in orb-publishing context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
           Semver-less name of the orb to be promoted into production
       orb-ref:
         type: string
-        description: >
+        description: |
           Version information of the orb to be promoted into production
     executor: cli/default
     steps:
@@ -440,6 +440,7 @@ workflows:
             - orb-tools/pack
       - orb-tools/publish-dev:
           orb-name: circleci/aws-eks
+          context: orb-publishing
           requires:
             - queue/block_workflow
       - orb-tools/trigger-integration-workflow:
@@ -665,6 +666,7 @@ workflows:
       - promote-orb-into-production:
           orb-name: circleci/aws-eks
           orb-ref: dev:${CIRCLE_SHA1:0:7}
+          context: orb-publishing
           requires:
             - hold-for-approval
           filters: *orb_promotion_filters

--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,8 @@ See the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/aw
 
 Full usage examples can be found on the AWS EKS orb's page in the orb registry, [here](https://circleci.com/orbs/registry/orb/circleci/aws-eks#usage-examples).
 
+A demo project is also available [here](https://github.com/CircleCI-Public/circleci-demo-aws-eks).
+
 ```
 version: 2.1
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -6,7 +6,7 @@ The notes here are primarily targeted at internal (CircleCI) contributors to the
 
 ### Required Project Environment Variables
 
-The following [environment variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) must be set for the project on CircleCI via the project settings page, before the project can be built successfully.
+The following [project environment variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) must be set for the project on CircleCI via the project settings page, before the project can be built successfully.
 
 | Variable                       | Description                      |
 | -------------------------------| ---------------------------------|
@@ -15,9 +15,17 @@ The following [environment variables](https://circleci.com/docs/2.0/env-vars/#se
 | `AWS_DEFAULT_REGION`           | Picked up by the AWS CLI              |
 | `AWS_RESOURCE_NAME_PREFIX`     | Prefix for some AWS resources created in tests. This is used just to make the project more portable.                |
 | `CIRCLECI_API_KEY`             | Used by the `queue` orb          |
-| `CIRCLE_TOKEN`                 | Used to publish the orb          |
 | `SKIP_TEST_ENV_CREATION`       | Set this to true when you want to skip EKS cluster creation to facilitate testing. The `test-ssh-access` job will be skipped when this is enabled. Note: This env var is only effective for the clusters that are created via `aws-eks` orb commands and not `aws-eks` orb jobs. |
 | `SKIP_TEST_ENV_TEARDOWN`       | Set this to true when you want to skip EKS cluster teardown to facilitate testing. Note: this is only effective for the clusters that are created via `aws-eks` orb commands and not `aws-eks` orb jobs. |
+
+### Required Context and Context Environment Variables
+
+The `orb-publishing` context is referenced in the build. In particular, the following [context environment variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-context) must be set in the `orb-publishing` context, before the project can be built successfully.
+
+| Variable                       | Description                      |
+| -------------------------------| ---------------------------------|
+| `CIRCLE_TOKEN`                 | CircleCI API token used to publish the orb  |
+
 
 ### AWS Resource Cleanup
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,9 @@
 
 version: 2.1
 
-description: >
-  An orb for working with Amazon Elastic Container Service for Kubernetes (Amazon EKS)
+description: |
+  An orb for working with Amazon Elastic Container Service for Kubernetes (Amazon EKS).
+  Project homepage: https://github.com/CircleCI-Public/aws-eks-orb
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.9


### PR DESCRIPTION
- Use CIRCLE_TOKEN defined in orb-publishing context (which has the necessary permissions for publishing production orbs in the `circleci` namespace) instead of a project env var
- Add link to project homepage in orb description