### PR TITLE
use AWS environment variables as defaults

### DIFF
--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -9,15 +9,17 @@ parameters:
     default: ""
   aws-region:
     description: |
-      AWS region that the EKS cluster will be created in.
+      AWS region for the EKS cluster.
+      If no value is specifeid, uses `$AWS_REGION` environment variable.
+      By default, AWS will create the cluster in the us-west-2 region.
     type: string
-    default: ""
+    default: "${AWS_REGION}"
   aws-profile:
     description: |
       The AWS profile to be used. If not specified, the configured default
       profile for your AWS CLI installation will be used.
     type: string
-    default: ""
+    default: "${AWS_PROFILE}"
   zones:
     description: |
       The AWS availability zones to be used  e.g. us-east-1a,us-east-1b,us-east-1d

--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -10,10 +10,10 @@ parameters:
   aws-region:
     description: |
       AWS region for the EKS cluster.
-      If no value is specifeid, uses `$AWS_REGION` environment variable.
+      If no value is specifeid, uses `$AWS_DEFAULT_REGION` environment variable.
       By default, AWS will create the cluster in the us-west-2 region.
     type: string
-    default: "${AWS_REGION}"
+    default: "${AWS_DEFAULT_REGION}"
   aws-profile:
     description: |
       The AWS profile to be used. If not specified, the configured default

--- a/src/commands/delete-cluster.yml
+++ b/src/commands/delete-cluster.yml
@@ -18,16 +18,17 @@ parameters:
     default: ""
   aws-region:
     description: |
-      AWS region that the EKS cluster will be created in.
-      If no value is specified, the cluster will be created in the us-west-2 region.
+      AWS region for the EKS cluster.
+      If no value is specifeid, uses `$AWS_REGION` environment variable.
+      By default, AWS will create the cluster in the us-west-2 region.
     type: string
-    default: ""
+    default: "${AWS_REGION}"
   aws-profile:
     description: |
       The AWS profile to be used. If not specified, the configured default
       profile for your AWS CLI installation will be used.
     type: string
-    default: ""
+    default: "${AWS_PROFILE}"
   wait:
     description: |
       Whether to wait for deletion of all resources before exiting

--- a/src/commands/delete-cluster.yml
+++ b/src/commands/delete-cluster.yml
@@ -19,10 +19,10 @@ parameters:
   aws-region:
     description: |
       AWS region for the EKS cluster.
-      If no value is specifeid, uses `$AWS_REGION` environment variable.
+      If no value is specifeid, uses `$AWS_DEFAULT_REGION` environment variable.
       By default, AWS will create the cluster in the us-west-2 region.
     type: string
-    default: "${AWS_REGION}"
+    default: "${AWS_DEFAULT_REGION}"
   aws-profile:
     description: |
       The AWS profile to be used. If not specified, the configured default

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -11,10 +11,10 @@ parameters:
   aws-region:
     description: |
       AWS region for the EKS cluster.
-      If no value is specifeid, uses `$AWS_REGION` environment variable.
+      If no value is specifeid, uses `$AWS_DEFAULT_REGION` environment variable.
       By default, AWS will create the cluster in the us-west-2 region.
     type: string
-    default: "${AWS_REGION}"
+    default: "${AWS_DEFAULT_REGION}"
   aws-profile:
     description: |
       The AWS profile to be used. If not specified, the configured default

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -10,16 +10,17 @@ parameters:
     type: string
   aws-region:
     description: |
-      The AWS region that the cluster is in. If not specified, the configured default
-      region for your AWS CLI installation will be used.
+      AWS region for the EKS cluster.
+      If no value is specifeid, uses `$AWS_REGION` environment variable.
+      By default, AWS will create the cluster in the us-west-2 region.
     type: string
-    default: ""
+    default: "${AWS_REGION}"
   aws-profile:
     description: |
       The AWS profile to be used. If not specified, the configured default
       profile for your AWS CLI installation will be used.
     type: string
-    default: ""
+    default: "${AWS_PROFILE}"
   kubeconfig-file-path:
     description: |
       Specifies a kubeconfig file to append the configuration details to.


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Closes #9

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

the environment variables for region and profile should
be the default so we don't accidentally overwrite the common
environment variables and instead use them where it makes
sense
