### PR TITLE
Reduce GitHub api usage [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
       - run:
           name: Test port forwarding
           command: |
-            export POD_NAME=$(kubectl get pods --namespace default -l "app=grafana,release=<< parameters.release-name >>" -o jsonpath="{.items[0].metadata.name}")
+            export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=grafana" -o jsonpath="{.items[0].metadata.name}")
             nohup kubectl --namespace default port-forward $POD_NAME 3000 &
             sleep 10
             # Test accessing Grafana from the build container through the port-forwarding setup
@@ -523,7 +523,7 @@ workflows:
       - test-authenticator:
           name: test-authenticator-options
           executor: aws-eks/python2
-          release-tag: "v0.3.0"
+          release-tag: "v0.5.0"
           requires:
             - setup-cluster-defaults
           filters: *integration_test_filters

--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@ A demo project is also available [here](https://github.com/CircleCI-Public/circl
 version: 2.1
 
 orbs:
-  aws-eks: circleci/aws-eks@0.2.3
+  aws-eks: circleci/aws-eks@x.y
   kubernetes: circleci/kubernetes@0.4.0
 
 jobs:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,7 +4,8 @@ version: 2.1
 description: |
   An orb for working with Amazon Elastic Container Service for Kubernetes (Amazon EKS).
 display:
-  home_url: https://github.com/CircleCI-Public/aws-eks-orb
+  home_url: https://aws.amazon.com/eks/
+  source_url: https://github.com/CircleCI-Public/aws-eks-orb
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
   helm: circleci/helm@0.1.0

--- a/src/commands/install-aws-iam-authenticator.yml
+++ b/src/commands/install-aws-iam-authenticator.yml
@@ -30,14 +30,17 @@ steps:
         RELEASE_TAG="<< parameters.release-tag >>"
         RELEASE_URL="https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest"
 
+        VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %{url_effective} "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/latest" | sed 's:.*/::')
         if [ -n "${RELEASE_TAG}" ]; then
-          RELEASE_URL="https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/tags/${RELEASE_TAG}"
+          VERSION="${RELEASE_TAG}"
         fi
 
-        DOWNLOAD_URL=$(curl -s --retry 5 "${RELEASE_URL}" \
-            | grep "${PLATFORM}" | awk '/browser_download_url/ {print $2}' | sed 's/"//g')
+        # extract version number
+        VERSION_NUMBER=$(echo $VERSION | cut -c 2-)
 
-        curl -L -o aws-iam-authenticator "$DOWNLOAD_URL"
+        DOWNLOAD_URL="https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${VERSION}/aws-iam-authenticator_${VERSION_NUMBER}_${PLATFORM}_amd64"
+
+        curl -L --fail --retry 3 -o aws-iam-authenticator "$DOWNLOAD_URL"
 
         chmod +x ./aws-iam-authenticator
 

--- a/src/commands/install-aws-iam-authenticator.yml
+++ b/src/commands/install-aws-iam-authenticator.yml
@@ -30,15 +30,19 @@ steps:
         RELEASE_TAG="<< parameters.release-tag >>"
         RELEASE_URL="https://api.github.com/repos/kubernetes-sigs/aws-iam-authenticator/releases/latest"
 
+        FILENAME="aws-iam-authenticator"
         VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %{url_effective} "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/latest" | sed 's:.*/::')
         if [ -n "${RELEASE_TAG}" ]; then
           VERSION="${RELEASE_TAG}"
+          if [ "${VERSION}" == "v0.3.0" ]; then
+            FILENAME="heptio-authenticator-aws"
+          fi
         fi
 
         # extract version number
         VERSION_NUMBER=$(echo $VERSION | cut -c 2-)
 
-        DOWNLOAD_URL="https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${VERSION}/aws-iam-authenticator_${VERSION_NUMBER}_${PLATFORM}_amd64"
+        DOWNLOAD_URL="https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${VERSION}/${FILENAME}_${VERSION_NUMBER}_${PLATFORM}_amd64"
 
         curl -L --fail --retry 3 -o aws-iam-authenticator "$DOWNLOAD_URL"
 


### PR DESCRIPTION
This PR mainly contains the following changes
- Reduces GitHub API usage to avoid GitHub rate limiting errors when downloading the aws iam authenticator
- Fix an integration test that has become broken