### PR TITLE
Update orb dependency versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ workflows:
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-helm
           release-name: grafana-release
           purge: true
-          timeout: 600
+          timeout: "600"
           requires:
             - aws-eks/install-helm-chart
           filters: *integration_test_filters

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,6 +7,6 @@ display:
   home_url: https://aws.amazon.com/eks/
   source_url: https://github.com/CircleCI-Public/aws-eks-orb
 orbs:
-  aws-cli: circleci/aws-cli@0.1.13
-  helm: circleci/helm@0.1.0
-  kubernetes: circleci/kubernetes@0.4.0
+  aws-cli: circleci/aws-cli@1.2.1
+  helm: circleci/helm@1.0.0
+  kubernetes: circleci/kubernetes@0.11.0

--- a/src/jobs/delete-helm-release.yml
+++ b/src/jobs/delete-helm-release.yml
@@ -20,17 +20,24 @@ parameters:
     type: string
   purge:
     description: |
+      Effective for helm 2 commands only (purging is the default in helm 3)
       Whether to remove the release from the store and make its name free for
       later use
     type: boolean
     default: false
+  keep-history:
+    description: |
+      Effective for helm 3 commands only.
+      Retains release history.
+    type: boolean
+    default: false
   timeout:
     description: |
-      Specify time in seconds to wait for any individual Kubernetes operation
-      (like Jobs for hooks)
-      A value of -1 will be ignored.
-    type: integer
-    default: -1
+      Specify a timeout value that will be passed as a --timeout argument
+      to the helm command. For helm 3, the unit of the duration must
+      be specified e.g. '300s'.
+    type: string
+    default: ""
   namespace:
     description: |
       The kubernetes namespace that should be used.
@@ -72,6 +79,16 @@ parameters:
       Specify the namespace of Tiller
     type: string
     default: ""
+  helm-version:
+    type: string
+    default: "v2.16.9"
+    description: the helm client version to install. e.g. v2.4.0
+  no-output-timeout:
+    description: |
+      Elapsed time that the helm command can run on CircleCI without output.
+      The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
+    type: string
+    default: "30m"
   aws-region:
     description: |
       AWS region that the EKS cluster is in.
@@ -91,8 +108,10 @@ steps:
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
   - helm/delete-helm-release:
+      helm-version: << parameters.helm-version >>
       release-name: << parameters.release-name >>
       purge: << parameters.purge >>
+      keep-history: << parameters.keep-history >>
       timeout: << parameters.timeout >>
       namespace: << parameters.namespace >>
       tls: << parameters.tls >>
@@ -102,3 +121,4 @@ steps:
       tls-key: << parameters.tls-key >>
       tls-verify: << parameters.tls-verify >>
       tiller-namespace: << parameters.tiller-namespace >>
+      no-output-timeout: << parameters.no-output-timeout >>

--- a/src/jobs/install-helm-chart.yml
+++ b/src/jobs/install-helm-chart.yml
@@ -78,6 +78,21 @@ parameters:
       Whether to wait for the installation to be complete
     type: boolean
     default: true
+  update-repositories:
+    description: |
+      Choose to update repositories by running helm repo update.
+    type: boolean
+    default: true
+  helm-version:
+    type: string
+    default: "v2.16.9"
+    description: the helm client version to install. e.g. v2.4.0
+  no-output-timeout:
+    description: |
+      Elapsed time that the helm command can run on CircleCI without output.
+      The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s”
+    type: string
+    default: "30m"
   aws-region:
     description: |
       AWS region that the EKS cluster is in.
@@ -97,10 +112,12 @@ steps:
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
   - helm/install-helm-chart:
+      helm-version: << parameters.helm-version >>
       chart: << parameters.chart >>
       release-name: << parameters.release-name >>
       values-to-override: << parameters.values-to-override >>
       namespace: << parameters.namespace >>
+      update-repositories: << parameters.update-repositories >>
       tls: << parameters.tls >>
       tls-ca-cert: << parameters.tls-ca-cert >>
       tls-cert: << parameters.tls-cert >>
@@ -109,3 +126,4 @@ steps:
       tls-verify: << parameters.tls-verify >>
       tiller-namespace: << parameters.tiller-namespace >>
       wait: << parameters.wait >>
+      no-output-timeout: << parameters.no-output-timeout >>

--- a/tests/kubernetes-dashboard/influxdb-heapster.yaml
+++ b/tests/kubernetes-dashboard/influxdb-heapster.yaml
@@ -4,13 +4,17 @@ metadata:
   name: heapster
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: heapster
   template:
     metadata:
       labels:

--- a/tests/kubernetes-dashboard/influxdb.yaml
+++ b/tests/kubernetes-dashboard/influxdb.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: influxdb
   template:
     metadata:
       labels:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The aws-cli orb version depended on by this orb does not recognize when
the aws-cli tool is already installed. Instead, it always installs
aws-cli via pip which is extremely slow (>45s, typically).

### Description

Updates dependent orb versions to the latest release.