### PR TITLE
Temporarily pin v0.5.1 of aws-iam-authenticator as default due to issue with 0.5.2 release [semver:patch]

### DIFF
--- a/src/commands/install-aws-iam-authenticator.yml
+++ b/src/commands/install-aws-iam-authenticator.yml
@@ -37,6 +37,9 @@ steps:
           if [ "${VERSION}" == "v0.3.0" ]; then
             FILENAME="heptio-authenticator-aws"
           fi
+        else
+          # Pin the latest as version v0.5.1 temporarily
+          VERSION="v0.5.1"
         fi
 
         # extract version number


### PR DESCRIPTION
This will help unblock users who are facing https://github.com/CircleCI-Public/aws-eks-orb/issues/32 in the meantime.

We can undo the pinning once https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/344 is resolved