### PR TITLE
Unpin 0.5.1 as the version of aws-iam-authenticator to download when none is specified [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,6 +608,7 @@ workflows:
           filters: *integration_test_filters
       - aws-eks/delete-cluster:
           name: delete-cluster-helm
+          authenticator-release-tag: 'v0.5.0'
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-helm
           wait: true
           requires:

--- a/src/commands/install-aws-iam-authenticator.yml
+++ b/src/commands/install-aws-iam-authenticator.yml
@@ -37,9 +37,6 @@ steps:
           if [ "${VERSION}" == "v0.3.0" ]; then
             FILENAME="heptio-authenticator-aws"
           fi
-        else
-          # Pin the latest as version v0.5.1 temporarily
-          VERSION="v0.5.1"
         fi
 
         # extract version number

--- a/src/jobs/delete-cluster.yml
+++ b/src/jobs/delete-cluster.yml
@@ -31,6 +31,11 @@ parameters:
       profile for your AWS CLI installation will be used.
     type: string
     default: ""
+  authenticator-release-tag:
+    description: |
+      Specifies which release-tag version of the authenticator to install.
+    type: string
+    default: ""
   wait:
     description: |
       Whether to wait for deletion of all resources before exiting
@@ -58,6 +63,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
+      authenticator-release-tag: << parameters.authenticator-release-tag >>
   - delete-cluster:
       cluster-name: << parameters.cluster-name >>
       aws-region: << parameters.aws-region >>

--- a/src/jobs/delete-helm-release.yml
+++ b/src/jobs/delete-helm-release.yml
@@ -100,6 +100,11 @@ parameters:
       profile for your AWS CLI installation will be used.
     type: string
     default: ""
+  authenticator-release-tag:
+    description: |
+      Specifies which release-tag version of the authenticator to install.
+    type: string
+    default: ""
 
 steps:
   - update-kubeconfig-with-authenticator:
@@ -107,6 +112,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
+      authenticator-release-tag: << parameters.authenticator-release-tag >>
   - helm/delete-helm-release:
       helm-version: << parameters.helm-version >>
       release-name: << parameters.release-name >>

--- a/src/jobs/install-helm-chart.yml
+++ b/src/jobs/install-helm-chart.yml
@@ -104,6 +104,11 @@ parameters:
       profile for your AWS CLI installation will be used.
     type: string
     default: ""
+  authenticator-release-tag:
+    description: |
+      Specifies which release-tag version of the authenticator to install.
+    type: string
+    default: ""
 
 steps:
   - update-kubeconfig-with-authenticator:
@@ -111,6 +116,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
+      authenticator-release-tag: << parameters.authenticator-release-tag >>
   - helm/install-helm-chart:
       helm-version: << parameters.helm-version >>
       chart: << parameters.chart >>

--- a/src/jobs/install-helm-on-cluster.yml
+++ b/src/jobs/install-helm-on-cluster.yml
@@ -86,6 +86,11 @@ parameters:
       profile for your AWS CLI installation will be used.
     type: string
     default: ""
+  authenticator-release-tag:
+    description: |
+      Specifies which release-tag version of the authenticator to install.
+    type: string
+    default: ""
 
 steps:
   - update-kubeconfig-with-authenticator:
@@ -93,6 +98,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
+      authenticator-release-tag: << parameters.authenticator-release-tag >>
   - helm/install-helm-on-cluster:
       tiller-tls: << parameters.tiller-tls >>
       tiller-tls-cert: << parameters.tiller-tls-cert >>

--- a/src/jobs/update-container-image.yml
+++ b/src/jobs/update-container-image.yml
@@ -81,6 +81,11 @@ parameters:
       Whether to show the kubectl command used.
     type: boolean
     default: false
+  authenticator-release-tag:
+    description: |
+      Specifies which release-tag version of the authenticator to install.
+    type: string
+    default: ""
 
 steps:
   - update-kubeconfig-with-authenticator:
@@ -88,6 +93,7 @@ steps:
       aws-region: << parameters.aws-region >>
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
+      authenticator-release-tag: << parameters.authenticator-release-tag >>
   - kubernetes/update-container-image:
       resource-name: << parameters.resource-name >>
       container-image-updates: << parameters.container-image-updates >>


### PR DESCRIPTION
- Resolve https://github.com/CircleCI-Public/aws-eks-orb/issues/34 : Unpin 0.5.1 as the version of aws-iam-authenticator to download when none is specified
-  Support specifying aws-iam-authenticator version wherever update-kubeconfig-with-authenticator is used in a job. This allows users of those jobs to specify a particular version.