### PR TITLE
Add conditional aws-cli install for update-kubeconfig-with-authenticator

### DIFF
--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -62,6 +62,11 @@ parameters:
       Whether to install kubectl
     type: boolean
     default: false
+  install-aws-cli:
+    description: |
+      Whether to install the aws-cli
+    type: boolean
+    default: true
 
 steps:
   - when:
@@ -70,7 +75,10 @@ steps:
         - kubernetes/install
   - install-aws-iam-authenticator:
       release-tag: << parameters.authenticator-release-tag >>
-  - aws-cli/install
+  - when:
+      condition: << parameters.install-aws-cli >>
+      steps:
+        - aws-cli/install
   - run:
       name: Update the kubectl configuration file to use the authenticator
       command: |


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

We set multiple contexts in our kube config, may possibly install the AWS CLI separately from `update-kubeconfig-with-authenticator` and so can end up with a job that looks like this. While it only takes a few seconds to check that the AWS CLI is installed, it's noisy in the UI and well a few seconds is a few seconds.

<img width="630" alt="Screen Shot 2021-09-11 at 7 26 22 AM" src="https://user-images.githubusercontent.com/3457341/132949469-c1fb7897-650f-4312-9be9-6657ffc64bed.png">

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This adds a parameter to `update-kubeconfig-with-authenticator` to not install the AWS CLI. There are cases where the CLI would have been installed previously and so we do not need to attempt to install it again. The parameter is true by default.
