### PR TITLE
Fix for aws-iam-authenticator 449

### DIFF
--- a/src/scripts/install-aws-iam-authenticator.sh
+++ b/src/scripts/install-aws-iam-authenticator.sh
@@ -9,9 +9,9 @@ then
     PLATFORM="darwin"
 fi
 FILENAME="aws-iam-authenticator"
-VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w "%{url_effective}" "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/latest" | sed 's:.*/::' | sed 's/v//g')
+VERSION=0.5.6
 if [ -n "${PARAM_RELEASE_TAG}" ]; then
-    export RELEASE_TAG=${!PARAM_RELEASE_TAG}
+    export RELEASE_TAG=${PARAM_RELEASE_TAG}
     VERSION="${RELEASE_TAG}"
     if [ "${VERSION}" == "0.3.0" ]; then
     FILENAME="heptio-authenticator-aws"
@@ -19,6 +19,8 @@ if [ -n "${PARAM_RELEASE_TAG}" ]; then
 fi
 
 DOWNLOAD_URL="https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${VERSION}/${FILENAME}_${VERSION}_${PLATFORM}_amd64"
+
+printf "Downloading version ${VERSION}\n"
 
 curl -L --fail --retry 3 -o aws-iam-authenticator "$DOWNLOAD_URL"
 chmod +x ./aws-iam-authenticator


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Emergency fix for https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/449

### Description

Default the version of `aws-iam-authenticator`  to `0.5.6`
Remove syntax error in line 14, affecting version string handling.
