### PR TITLE
Add option to specify kubectl version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,16 +200,10 @@ jobs:
         default: ""
       cluster-name:
         type: string
-      kubectl-version:
-        description: |
-          Version of kubectl to install (v1.24.0 of kubectl breaks client.authentication.k8s.io/v1alpha1)
-        type: string
-        default: "v1.21.0"
     executor: << parameters.executor >>
     steps:
       - checkout
-      - kubernetes/install:
-          kubectl-version: << parameters.kubectl-version >>
+      - kubernetes/install
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       # Test various update-kubeconfig options
@@ -301,11 +295,6 @@ jobs:
       region:
         type: string
         default: ""
-      kubectl-version:
-        description: |
-          Version of kubectl to install (v1.24.0 of kubectl breaks client.authentication.k8s.io/v1alpha1)
-        type: string
-        default: "v1.21.0"
     executor: << parameters.executor >>
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
@@ -322,8 +311,7 @@ jobs:
           name: Test aws-iam-authenticator
           command: |
             aws-iam-authenticator
-      - kubernetes/install:
-          kubectl-version: << parameters.kubectl-version >>
+      - kubernetes/install
       - run:
           name: Test with kubectl
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - checkout
-      - kubernetes/install
+      - kubernetes/install:
+          kubectl-version: v1.22.0
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       # Test various update-kubeconfig options
@@ -311,7 +312,8 @@ jobs:
           name: Test aws-iam-authenticator
           command: |
             aws-iam-authenticator
-      - kubernetes/install
+      - kubernetes/install:
+          kubectl-version: v1.22.0
       - run:
           name: Test with kubectl
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,16 @@ jobs:
         default: ""
       cluster-name:
         type: string
+      kubectl-version:
+        description: |
+          Version of kubectl to install (v1.24.0 of kubectl breaks client.authentication.k8s.io/v1alpha1)
+        type: string
+        default: "v1.21.0"
     executor: << parameters.executor >>
     steps:
       - checkout
-      - kubernetes/install
+      - kubernetes/install:
+          kubectl-version: << parameters.kubectl-version >>
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       # Test various update-kubeconfig options
@@ -295,6 +301,11 @@ jobs:
       region:
         type: string
         default: ""
+      kubectl-version:
+        description: |
+          Version of kubectl to install (v1.24.0 of kubectl breaks client.authentication.k8s.io/v1alpha1)
+        type: string
+        default: "v1.21.0"
     executor: << parameters.executor >>
     steps:
       - aws-eks/update-kubeconfig-with-authenticator:
@@ -311,7 +322,8 @@ jobs:
           name: Test aws-iam-authenticator
           command: |
             aws-iam-authenticator
-      - kubernetes/install
+      - kubernetes/install:
+          kubectl-version: << parameters.kubectl-version >>
       - run:
           name: Test with kubectl
           command: |

--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -203,7 +203,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "latest"
+    default: "v1.22.0"
   aws-max-polling-wait-time:
     description: |
       Max wait time in any AWS polling operations

--- a/src/commands/create-cluster.yml
+++ b/src/commands/create-cluster.yml
@@ -199,6 +199,11 @@ parameters:
       Whether to skip the installation of kubectl.
     type: boolean
     default: false
+  kubectl-version:
+    description: |
+      Version of kubectl to install
+    type: string
+    default: "latest"
   aws-max-polling-wait-time:
     description: |
       Max wait time in any AWS polling operations
@@ -221,7 +226,8 @@ steps:
   - unless:
       condition: << parameters.skip-kubectl-install >>
       steps:
-        - kubernetes/install
+        - kubernetes/install:
+            kubectl-version: << parameters.kubectl-version >>
   - run:
       environment:
         PARAM_CLUSTER_NAME: << parameters.cluster-name >>

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -66,7 +66,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "latest"
+    default: "v1.22.0"
   install-aws-cli:
     description: |
       Whether to install aws-cli

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -62,6 +62,11 @@ parameters:
       Whether to install kubectl
     type: boolean
     default: false
+  kubectl-version:
+    description: |
+      Version of kubectl to install
+    type: string
+    default: "latest"
   install-aws-cli:
     description: |
       Whether to install aws-cli
@@ -72,7 +77,8 @@ steps:
   - when:
       condition: << parameters.install-kubectl >>
       steps:
-        - kubernetes/install
+        - kubernetes/install:
+            kubectl-version: << parameters.kubectl-version >>
   - install-aws-iam-authenticator:
       release-tag: << parameters.authenticator-release-tag >>
   - when:

--- a/src/examples/create-eks-cluster.yml
+++ b/src/examples/create-eks-cluster.yml
@@ -18,7 +18,8 @@ usage:
             Name of the EKS cluster
           type: string
       steps:
-        - kubernetes/install
+        - kubernetes/install:
+            kubectl-version: v1.22.0
         - aws-eks/update-kubeconfig-with-authenticator:
             cluster-name: << parameters.cluster-name >>
         - run:

--- a/src/jobs/delete-cluster.yml
+++ b/src/jobs/delete-cluster.yml
@@ -38,6 +38,11 @@ parameters:
       Specifies which release-tag version of the authenticator to install.
     type: string
     default: ""
+  kubectl-version:
+    description: |
+      Version of kubectl to install
+    type: string
+    default: "latest"
   wait:
     description: |
       Whether to wait for deletion of all resources before exiting
@@ -66,6 +71,7 @@ steps:
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
       authenticator-release-tag: << parameters.authenticator-release-tag >>
+      kubectl-version: << parameters.kubectl-version >>
   - delete-cluster:
       cluster-name: << parameters.cluster-name >>
       aws-region: << parameters.aws-region >>

--- a/src/jobs/delete-cluster.yml
+++ b/src/jobs/delete-cluster.yml
@@ -42,7 +42,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "latest"
+    default: "v1.22.0"
   wait:
     description: |
       Whether to wait for deletion of all resources before exiting

--- a/src/jobs/update-container-image.yml
+++ b/src/jobs/update-container-image.yml
@@ -88,7 +88,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "latest"
+    default: "v1.22.0"
 
 steps:
   - update-kubeconfig-with-authenticator:

--- a/src/jobs/update-container-image.yml
+++ b/src/jobs/update-container-image.yml
@@ -84,6 +84,11 @@ parameters:
       Specifies which release-tag version of the authenticator to install.
     type: string
     default: ""
+  kubectl-version:
+    description: |
+      Version of kubectl to install
+    type: string
+    default: "latest"
 
 steps:
   - update-kubeconfig-with-authenticator:
@@ -92,6 +97,7 @@ steps:
       aws-profile: << parameters.aws-profile >>
       install-kubectl: true
       authenticator-release-tag: << parameters.authenticator-release-tag >>
+      kubectl-version: << parameters.kubectl-version >>
   - kubernetes/update-container-image:
       resource-name: << parameters.resource-name >>
       container-image-updates: << parameters.container-image-updates >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

kubectl v1.24.0 introduces breaking change to api version.
fixes https://github.com/CircleCI-Public/aws-eks-orb/issues/67

### Description

- add kubectl-version parameter to commands that install kubectl
- add kubectl-version parameter to jobs that install kubectl
