### PR TITLE
feat!/auth-step parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -4,7 +4,7 @@ orbs:
   orb-tools: circleci/orb-tools@11.6
   aws-cli: circleci/aws-cli@3.1
   helm: circleci/helm@2.0
-  kubernetes: circleci/kubernetes@1.0
+  kubernetes: circleci/kubernetes@1.3
   shellcheck: circleci/shellcheck@3.1
   browser-tools: circleci/browser-tools@1.4
 filters: &filters
@@ -46,6 +46,8 @@ jobs:
         type: string
     steps:
       - cluster-setup-check
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/install-aws-iam-authenticator
       - aws-eks/create-cluster:
           cluster-name: << parameters.cluster-name >>
@@ -102,6 +104,8 @@ jobs:
         default: ""
     steps:
       - cluster-setup-check
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/install-aws-iam-authenticator
       - run:
           name: Generate ssh keys
@@ -238,6 +242,8 @@ jobs:
         default: ""
     executor: << parameters.executor >>
     steps:
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           aws-profile: << parameters.profile >>
@@ -275,6 +281,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - cluster-setup-check
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           aws-region: << parameters.region >>
@@ -359,135 +367,135 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      # - integration-test-installs:
-      #     name: integration-test-installs-<< matrix.executor >>
-      #     context: orb-publisher
-      #     filters: *filters
-      #     matrix:
-      #       parameters:
-      #         executor: ["docker", "macos", "machine"]
-      # - setup-cluster:
-      #     name: setup-cluster-defaults
-      #     context: [CPE-OIDC]
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-installs-docker
-      #       - integration-test-installs-macos
-      #       - integration-test-installs-machine
-      # - test-cluster:
-      #     name: test-cluster-defaults
-      #     executor: python
-      #     context: [CPE-OIDC]
-      #     region: $AWS_DEFAULT_REGION
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-      #     filters: *filters
-      #     requires:
-      #       - setup-cluster-defaults
-      # - test-authenticator:
-      #     name: test-authenticator-<< matrix.executor >>
-      #     matrix:
-      #       parameters:
-      #         executor: ["docker", "macos", "machine"]
-      #     filters: *filters
-      #     requires:
-      #       - setup-cluster-defaults
-      # - test-update-kubeconfig:
-      #     name: test-update-kubeconfig-region-<< matrix.executor >>
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-      #     context: [CPE-OIDC]
-      #     region: $AWS_DEFAULT_REGION
-      #     filters: *filters
-      #     matrix:
-      #       parameters:
-      #         executor: ["docker", "macos", "machine"]
-      #     requires:
-      #       - setup-cluster-defaults
-      # - delete-cluster:
-      #     name: delete-cluster-defaults
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-      #     region: "us-west-2"
-      #     wait: true
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     requires:
-      #       - test-authenticator-docker
-      #       - test-authenticator-macos
-      #       - test-authenticator-machine
-      #       - test-update-kubeconfig-region-docker
-      #       - test-update-kubeconfig-region-macos
-      #       - test-update-kubeconfig-region-machine
-      #       - test-cluster-defaults
-      # - setup-cluster-with-many-params:
-      #     name: setup-cluster-custom-values
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     zones: "us-west-2a,us-west-2c"
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-installs-docker
-      #       - integration-test-installs-macos
-      #       - integration-test-installs-machine
-      # - test-cluster:
-      #     name: test-cluster-custom-values
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     executor: python
-      #     filters: *filters
-      #     requires:
-      #       - setup-cluster-custom-values
-      # - delete-cluster:
-      #     name: delete-cluster-custom-values       
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     wait: true
-      #     filters: *filters
-      #     requires:
-      #       - test-cluster-custom-values
-      # - setup-cluster-with-ssh:
-      #     name: setup-cluster-custom-values-ssh
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     zones: "us-west-2b,us-west-2c"
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-installs-docker
-      #       - integration-test-installs-macos
-      #       - integration-test-installs-machine
-      # - test-cluster:
-      #     name: test-cluster-custom-values-ssh
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE-OIDC]
-      #     executor: python
-      #     region: "us-west-2"
-      #     filters: *filters
-      #     requires:
-      #       - setup-cluster-custom-values-ssh
-      # - test-ssh-access:
-      #     name: test-ssh-access
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     release-name: grafana
-      #     add-repo: https://grafana.github.io/helm-charts
-      #     executor: python
-      #     filters: *filters
-      #     requires:
-      #       - test-cluster-custom-values-ssh
-      # - delete-cluster:
-      #     name: delete-cluster-custom-values-ssh
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     filters: *filters
-      #     wait: true
-      #     requires:
-      #       - test-ssh-access
-      #       - test-cluster-custom-values-ssh
+      - integration-test-installs:
+          name: integration-test-installs-<< matrix.executor >>
+          context: orb-publisher
+          filters: *filters
+          matrix:
+            parameters:
+              executor: ["docker", "macos", "machine"]
+      - setup-cluster:
+          name: setup-cluster-defaults
+          context: [CPE-OIDC]
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+          filters: *filters
+          requires:
+            - integration-test-installs-docker
+            - integration-test-installs-macos
+            - integration-test-installs-machine
+      - test-cluster:
+          name: test-cluster-defaults
+          executor: python
+          context: [CPE-OIDC]
+          region: $AWS_DEFAULT_REGION
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+          filters: *filters
+          requires:
+            - setup-cluster-defaults
+      - test-authenticator:
+          name: test-authenticator-<< matrix.executor >>
+          matrix:
+            parameters:
+              executor: ["docker", "macos", "machine"]
+          filters: *filters
+          requires:
+            - setup-cluster-defaults
+      - test-update-kubeconfig:
+          name: test-update-kubeconfig-region-<< matrix.executor >>
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+          context: [CPE-OIDC]
+          region: $AWS_DEFAULT_REGION
+          filters: *filters
+          matrix:
+            parameters:
+              executor: ["docker", "macos", "machine"]
+          requires:
+            - setup-cluster-defaults
+      - delete-cluster:
+          name: delete-cluster-defaults
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+          region: "us-west-2"
+          wait: true
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - test-authenticator-docker
+            - test-authenticator-macos
+            - test-authenticator-machine
+            - test-update-kubeconfig-region-docker
+            - test-update-kubeconfig-region-macos
+            - test-update-kubeconfig-region-machine
+            - test-cluster-defaults
+      - setup-cluster-with-many-params:
+          name: setup-cluster-custom-values
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          zones: "us-west-2a,us-west-2c"
+          filters: *filters
+          requires:
+            - integration-test-installs-docker
+            - integration-test-installs-macos
+            - integration-test-installs-machine
+      - test-cluster:
+          name: test-cluster-custom-values
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          executor: python
+          filters: *filters
+          requires:
+            - setup-cluster-custom-values
+      - delete-cluster:
+          name: delete-cluster-custom-values       
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          wait: true
+          filters: *filters
+          requires:
+            - test-cluster-custom-values
+      - setup-cluster-with-ssh:
+          name: setup-cluster-custom-values-ssh
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          zones: "us-west-2b,us-west-2c"
+          filters: *filters
+          requires:
+            - integration-test-installs-docker
+            - integration-test-installs-macos
+            - integration-test-installs-machine
+      - test-cluster:
+          name: test-cluster-custom-values-ssh
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+          context: [CPE-OIDC]
+          executor: python
+          region: "us-west-2"
+          filters: *filters
+          requires:
+            - setup-cluster-custom-values-ssh
+      - test-ssh-access:
+          name: test-ssh-access
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          release-name: grafana
+          add-repo: https://grafana.github.io/helm-charts
+          executor: python
+          filters: *filters
+          requires:
+            - test-cluster-custom-values-ssh
+      - delete-cluster:
+          name: delete-cluster-custom-values-ssh
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          filters: *filters
+          wait: true
+          requires:
+            - test-ssh-access
+            - test-cluster-custom-values-ssh
       #Kubectl Tests
       - aws-eks/create-cluster:
           name: setup-cluster-kubectl
@@ -498,10 +506,10 @@ workflows:
           context: [CPE-OIDC]
           aws-region: "us-west-2"
           filters: *filters
-          # requires:
-          #   - integration-test-installs-docker
-          #   - integration-test-installs-macos
-          #   - integration-test-installs-machine
+          requires:
+            - integration-test-installs-docker
+            - integration-test-installs-macos
+            - integration-test-installs-machine
       - create-deployment:
           name: create-deployment-kubectl
           executor: python
@@ -544,55 +552,55 @@ workflows:
           requires:
             - update-container-image-kubectl
       # #Fargate Tests
-      # - setup-cluster-with-many-params:
-      #     name: setup-cluster-fargate
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-      #     region: "us-west-2"
-      #     fargate: true
-      #     zones: "us-west-2a,us-west-2c"
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-installs-docker
-      #       - integration-test-installs-macos
-      #       - integration-test-installs-machine
-      # - test-cluster:
-      #     name: test-cluster-fargate
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     executor: python
-      #     filters: *filters
-      #     requires:
-      #       - setup-cluster-fargate
-      # - delete-cluster:
-      #     name: delete-cluster-fargate
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-      #     context: [CPE-OIDC]
-      #     region: "us-west-2"
-      #     wait: true
-      #     filters: *filters          
-      #     requires:
-      #       - test-cluster-fargate      
-      # - orb-tools/pack:
-      #     filters: *filters
-      # - orb-tools/publish:
-      #     orb-name: circleci/aws-eks
-      #     vcs-type: << pipeline.project.type >>
-      #     pub-type: production
-      #     requires:
-      #       - orb-tools/pack
-      #       - delete-cluster-fargate
-      #       - delete-cluster-kubectl
-      #       - delete-cluster-custom-values-ssh
-      #       - delete-cluster-custom-values
-      #       - delete-cluster-defaults
-      #     context: orb-publisher
-      #     filters:
-      #       branches:
-      #         ignore: /.*/
-      #       tags:
-      #         only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - setup-cluster-with-many-params:
+          name: setup-cluster-fargate
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
+          region: "us-west-2"
+          fargate: true
+          zones: "us-west-2a,us-west-2c"
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - integration-test-installs-docker
+            - integration-test-installs-macos
+            - integration-test-installs-machine
+      - test-cluster:
+          name: test-cluster-fargate
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          executor: python
+          filters: *filters
+          requires:
+            - setup-cluster-fargate
+      - delete-cluster:
+          name: delete-cluster-fargate
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          wait: true
+          filters: *filters          
+          requires:
+            - test-cluster-fargate      
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: circleci/aws-eks
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - orb-tools/pack
+            - delete-cluster-fargate
+            - delete-cluster-kubectl
+            - delete-cluster-custom-values-ssh
+            - delete-cluster-custom-values
+            - delete-cluster-defaults
+          context: orb-publisher
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 executors:
   docker:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -344,6 +344,8 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - checkout
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           aws-region: << parameters.region >>
@@ -366,7 +368,7 @@ workflows:
       #         executor: ["docker", "macos", "machine"]
       # - setup-cluster:
       #     name: setup-cluster-defaults
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
       #     filters: *filters
       #     requires:
@@ -376,7 +378,7 @@ workflows:
       # - test-cluster:
       #     name: test-cluster-defaults
       #     executor: python
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: $AWS_DEFAULT_REGION
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
       #     filters: *filters
@@ -393,7 +395,7 @@ workflows:
       # - test-update-kubeconfig:
       #     name: test-update-kubeconfig-region-<< matrix.executor >>
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: $AWS_DEFAULT_REGION
       #     filters: *filters
       #     matrix:
@@ -406,7 +408,7 @@ workflows:
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
       #     region: "us-west-2"
       #     wait: true
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     filters: *filters
       #     requires:
       #       - test-authenticator-docker
@@ -416,39 +418,39 @@ workflows:
       #       - test-update-kubeconfig-region-macos
       #       - test-update-kubeconfig-region-machine
       #       - test-cluster-defaults
-      - setup-cluster-with-many-params:
-          name: setup-cluster-custom-values
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-          context: [CPE-OIDC]
-          region: "us-west-2"
-          zones: "us-west-2a,us-west-2c"
-          filters: *filters
-          # requires:
-          #   - integration-test-installs-docker
-          #   - integration-test-installs-macos
-          #   - integration-test-installs-machine
-      - test-cluster:
-          name: test-cluster-custom-values
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-          context: [CPE-OIDC]
-          region: "us-west-2"
-          executor: python
-          filters: *filters
-          requires:
-            - setup-cluster-custom-values
-      - delete-cluster:
-          name: delete-cluster-custom-values       
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-          context: [CPE-OIDC]
-          region: "us-west-2"
-          wait: true
-          filters: *filters
-          requires:
-            - test-cluster-custom-values
+      # - setup-cluster-with-many-params:
+      #     name: setup-cluster-custom-values
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
+      #     context: [CPE-OIDC]
+      #     region: "us-west-2"
+      #     zones: "us-west-2a,us-west-2c"
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-installs-docker
+      #       - integration-test-installs-macos
+      #       - integration-test-installs-machine
+      # - test-cluster:
+      #     name: test-cluster-custom-values
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
+      #     context: [CPE-OIDC]
+      #     region: "us-west-2"
+      #     executor: python
+      #     filters: *filters
+      #     requires:
+      #       - setup-cluster-custom-values
+      # - delete-cluster:
+      #     name: delete-cluster-custom-values       
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
+      #     context: [CPE-OIDC]
+      #     region: "us-west-2"
+      #     wait: true
+      #     filters: *filters
+      #     requires:
+      #       - test-cluster-custom-values
       # - setup-cluster-with-ssh:
       #     name: setup-cluster-custom-values-ssh
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: "us-west-2"
       #     zones: "us-west-2b,us-west-2c"
       #     filters: *filters
@@ -459,7 +461,7 @@ workflows:
       # - test-cluster:
       #     name: test-cluster-custom-values-ssh
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     executor: python
       #     region: "us-west-2"
       #     filters: *filters
@@ -468,7 +470,7 @@ workflows:
       # - test-ssh-access:
       #     name: test-ssh-access
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: "us-west-2"
       #     release-name: grafana
       #     add-repo: https://grafana.github.io/helm-charts
@@ -479,59 +481,68 @@ workflows:
       # - delete-cluster:
       #     name: delete-cluster-custom-values-ssh
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: "us-west-2"
       #     filters: *filters
       #     wait: true
       #     requires:
       #       - test-ssh-access
       #       - test-cluster-custom-values-ssh
-      # #Kubectl Tests
-      # - aws-eks/create-cluster:
-      #     name: setup-cluster-kubectl
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-      #     context: [CPE_ORBS_AWS]
-      #     aws-region: "us-west-2"
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-installs-docker
-      #       - integration-test-installs-macos
-      #       - integration-test-installs-machine
-      # - create-deployment:
-      #     name: create-deployment-kubectl
-      #     executor: python
-      #     context: [CPE_ORBS_AWS]
-      #     region: "us-west-2"
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-      #     filters: *filters
-      #     requires:
-      #       - setup-cluster-kubectl
-      # - aws-eks/update-container-image:
-      #     name: update-container-image-kubectl
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-      #     context: [CPE_ORBS_AWS]
-      #     aws-region: "us-west-2"
-      #     resource-name: "deployment/nginx-deployment"
-      #     container-image-updates: "nginx=nginx:1.9.1"
-      #     get-rollout-status: true
-      #     filters: *filters
-      #     post-steps:
-      #       - kubernetes/delete-resource:
-      #           resource-types: "deployments"
-      #           resource-names: "nginx-deployment"
-      #           now: true
-      #           wait: true
-      #     requires:
-      #       - create-deployment-kubectl
-      # - aws-eks/delete-cluster:
-      #     name: delete-cluster-kubectl
-      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-      #     context: [CPE_ORBS_AWS]
-      #     aws-region: "us-west-2"
-      #     wait: true
-      #     filters: *filters
-      #     requires:
-      #       - update-container-image-kubectl
+      #Kubectl Tests
+      - aws-eks/create-cluster:
+          name: setup-cluster-kubectl
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+          context: [CPE-OIDC]
+          aws-region: "us-west-2"
+          filters: *filters
+          # requires:
+          #   - integration-test-installs-docker
+          #   - integration-test-installs-macos
+          #   - integration-test-installs-machine
+      - create-deployment:
+          name: create-deployment-kubectl
+          executor: python
+          context: [CPE-OIDC]
+          region: "us-west-2"
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+          filters: *filters
+          requires:
+            - setup-cluster-kubectl
+      - aws-eks/update-container-image:
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
+          name: update-container-image-kubectl
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+          context: [CPE-OIDC]
+          aws-region: "us-west-2"
+          resource-name: "deployment/nginx-deployment"
+          container-image-updates: "nginx=nginx:1.9.1"
+          get-rollout-status: true
+          filters: *filters
+          post-steps:
+            - kubernetes/delete-resource:
+                resource-types: "deployments"
+                resource-names: "nginx-deployment"
+                now: true
+                wait: true
+          requires:
+            - create-deployment-kubectl
+      - aws-eks/delete-cluster:
+          name: delete-cluster-kubectl
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
+          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+          context: [CPE-OIDC]
+          aws-region: "us-west-2"
+          wait: true
+          filters: *filters
+          requires:
+            - update-container-image-kubectl
       # #Fargate Tests
       # - setup-cluster-with-many-params:
       #     name: setup-cluster-fargate
@@ -539,7 +550,7 @@ workflows:
       #     region: "us-west-2"
       #     fargate: true
       #     zones: "us-west-2a,us-west-2c"
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     filters: *filters
       #     requires:
       #       - integration-test-installs-docker
@@ -548,7 +559,7 @@ workflows:
       # - test-cluster:
       #     name: test-cluster-fargate
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: "us-west-2"
       #     executor: python
       #     filters: *filters
@@ -557,7 +568,7 @@ workflows:
       # - delete-cluster:
       #     name: delete-cluster-fargate
       #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-      #     context: [CPE_ORBS_AWS]
+      #     context: [CPE-OIDC]
       #     region: "us-west-2"
       #     wait: true
       #     filters: *filters          

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -66,6 +66,8 @@ jobs:
         default: false
     steps:
       - cluster-setup-check
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/install-aws-iam-authenticator
       - aws-eks/create-cluster:
           cluster-name: << parameters.cluster-name >>
@@ -144,6 +146,8 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       # Test various update-kubeconfig options
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           aws-region: << parameters.region >>
@@ -314,6 +318,8 @@ jobs:
       wait:
         type: boolean
     steps:
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_EKS_OIDC_TEST
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: << parameters.cluster-name >>
           aws-region: << parameters.region >>
@@ -431,7 +437,7 @@ workflows:
           requires:
             - setup-cluster-custom-values
       - delete-cluster:
-          name: delete-cluster-custom-values
+          name: delete-cluster-custom-values       
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
           context: [CPE-OIDC]
           region: "us-west-2"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -351,80 +351,80 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - integration-test-installs:
-          name: integration-test-installs-<< matrix.executor >>
-          context: orb-publisher
-          filters: *filters
-          matrix:
-            parameters:
-              executor: ["docker", "macos", "machine"]
-      - setup-cluster:
-          name: setup-cluster-defaults
-          context: [CPE_ORBS_AWS]
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-          filters: *filters
-          requires:
-            - integration-test-installs-docker
-            - integration-test-installs-macos
-            - integration-test-installs-machine
-      - test-cluster:
-          name: test-cluster-defaults
-          executor: python
-          context: [CPE_ORBS_AWS]
-          region: $AWS_DEFAULT_REGION
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-          filters: *filters
-          requires:
-            - setup-cluster-defaults
-      - test-authenticator:
-          name: test-authenticator-<< matrix.executor >>
-          matrix:
-            parameters:
-              executor: ["docker", "macos", "machine"]
-          filters: *filters
-          requires:
-            - setup-cluster-defaults
-      - test-update-kubeconfig:
-          name: test-update-kubeconfig-region-<< matrix.executor >>
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-          context: [CPE_ORBS_AWS]
-          region: $AWS_DEFAULT_REGION
-          filters: *filters
-          matrix:
-            parameters:
-              executor: ["docker", "macos", "machine"]
-          requires:
-            - setup-cluster-defaults
-      - delete-cluster:
-          name: delete-cluster-defaults
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
-          region: "us-west-2"
-          wait: true
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - test-authenticator-docker
-            - test-authenticator-macos
-            - test-authenticator-machine
-            - test-update-kubeconfig-region-docker
-            - test-update-kubeconfig-region-macos
-            - test-update-kubeconfig-region-machine
-            - test-cluster-defaults
+      # - integration-test-installs:
+      #     name: integration-test-installs-<< matrix.executor >>
+      #     context: orb-publisher
+      #     filters: *filters
+      #     matrix:
+      #       parameters:
+      #         executor: ["docker", "macos", "machine"]
+      # - setup-cluster:
+      #     name: setup-cluster-defaults
+      #     context: [CPE_ORBS_AWS]
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-installs-docker
+      #       - integration-test-installs-macos
+      #       - integration-test-installs-machine
+      # - test-cluster:
+      #     name: test-cluster-defaults
+      #     executor: python
+      #     context: [CPE_ORBS_AWS]
+      #     region: $AWS_DEFAULT_REGION
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+      #     filters: *filters
+      #     requires:
+      #       - setup-cluster-defaults
+      # - test-authenticator:
+      #     name: test-authenticator-<< matrix.executor >>
+      #     matrix:
+      #       parameters:
+      #         executor: ["docker", "macos", "machine"]
+      #     filters: *filters
+      #     requires:
+      #       - setup-cluster-defaults
+      # - test-update-kubeconfig:
+      #     name: test-update-kubeconfig-region-<< matrix.executor >>
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+      #     context: [CPE_ORBS_AWS]
+      #     region: $AWS_DEFAULT_REGION
+      #     filters: *filters
+      #     matrix:
+      #       parameters:
+      #         executor: ["docker", "macos", "machine"]
+      #     requires:
+      #       - setup-cluster-defaults
+      # - delete-cluster:
+      #     name: delete-cluster-defaults
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-defaults
+      #     region: "us-west-2"
+      #     wait: true
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - test-authenticator-docker
+      #       - test-authenticator-macos
+      #       - test-authenticator-machine
+      #       - test-update-kubeconfig-region-docker
+      #       - test-update-kubeconfig-region-macos
+      #       - test-update-kubeconfig-region-machine
+      #       - test-cluster-defaults
       - setup-cluster-with-many-params:
           name: setup-cluster-custom-values
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-          context: [CPE_ORBS_AWS]
+          context: [CPE-OIDC]
           region: "us-west-2"
           zones: "us-west-2a,us-west-2c"
           filters: *filters
-          requires:
-            - integration-test-installs-docker
-            - integration-test-installs-macos
-            - integration-test-installs-machine
+          # requires:
+          #   - integration-test-installs-docker
+          #   - integration-test-installs-macos
+          #   - integration-test-installs-machine
       - test-cluster:
           name: test-cluster-custom-values
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-          context: [CPE_ORBS_AWS]
+          context: [CPE-OIDC]
           region: "us-west-2"
           executor: python
           filters: *filters
@@ -433,149 +433,149 @@ workflows:
       - delete-cluster:
           name: delete-cluster-custom-values
           cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values
-          context: [CPE_ORBS_AWS]
+          context: [CPE-OIDC]
           region: "us-west-2"
           wait: true
           filters: *filters
           requires:
             - test-cluster-custom-values
-      - setup-cluster-with-ssh:
-          name: setup-cluster-custom-values-ssh
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-          context: [CPE_ORBS_AWS]
-          region: "us-west-2"
-          zones: "us-west-2b,us-west-2c"
-          filters: *filters
-          requires:
-            - integration-test-installs-docker
-            - integration-test-installs-macos
-            - integration-test-installs-machine
-      - test-cluster:
-          name: test-cluster-custom-values-ssh
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-          context: [CPE_ORBS_AWS]
-          executor: python
-          region: "us-west-2"
-          filters: *filters
-          requires:
-            - setup-cluster-custom-values-ssh
-      - test-ssh-access:
-          name: test-ssh-access
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-          context: [CPE_ORBS_AWS]
-          region: "us-west-2"
-          release-name: grafana
-          add-repo: https://grafana.github.io/helm-charts
-          executor: python
-          filters: *filters
-          requires:
-            - test-cluster-custom-values-ssh
-      - delete-cluster:
-          name: delete-cluster-custom-values-ssh
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
-          context: [CPE_ORBS_AWS]
-          region: "us-west-2"
-          filters: *filters
-          wait: true
-          requires:
-            - test-ssh-access
-            - test-cluster-custom-values-ssh
-      #Kubectl Tests
-      - aws-eks/create-cluster:
-          name: setup-cluster-kubectl
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-          context: [CPE_ORBS_AWS]
-          aws-region: "us-west-2"
-          filters: *filters
-          requires:
-            - integration-test-installs-docker
-            - integration-test-installs-macos
-            - integration-test-installs-machine
-      - create-deployment:
-          name: create-deployment-kubectl
-          executor: python
-          context: [CPE_ORBS_AWS]
-          region: "us-west-2"
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-          filters: *filters
-          requires:
-            - setup-cluster-kubectl
-      - aws-eks/update-container-image:
-          name: update-container-image-kubectl
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-          context: [CPE_ORBS_AWS]
-          aws-region: "us-west-2"
-          resource-name: "deployment/nginx-deployment"
-          container-image-updates: "nginx=nginx:1.9.1"
-          get-rollout-status: true
-          filters: *filters
-          post-steps:
-            - kubernetes/delete-resource:
-                resource-types: "deployments"
-                resource-names: "nginx-deployment"
-                now: true
-                wait: true
-          requires:
-            - create-deployment-kubectl
-      - aws-eks/delete-cluster:
-          name: delete-cluster-kubectl
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
-          context: [CPE_ORBS_AWS]
-          aws-region: "us-west-2"
-          wait: true
-          filters: *filters
-          requires:
-            - update-container-image-kubectl
-      #Fargate Tests
-      - setup-cluster-with-many-params:
-          name: setup-cluster-fargate
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-          region: "us-west-2"
-          fargate: true
-          zones: "us-west-2a,us-west-2c"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - integration-test-installs-docker
-            - integration-test-installs-macos
-            - integration-test-installs-machine
-      - test-cluster:
-          name: test-cluster-fargate
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-          context: [CPE_ORBS_AWS]
-          region: "us-west-2"
-          executor: python
-          filters: *filters
-          requires:
-            - setup-cluster-fargate
-      - delete-cluster:
-          name: delete-cluster-fargate
-          cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
-          context: [CPE_ORBS_AWS]
-          region: "us-west-2"
-          wait: true
-          filters: *filters          
-          requires:
-            - test-cluster-fargate      
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/aws-eks
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
-          requires:
-            - orb-tools/pack
-            - delete-cluster-fargate
-            - delete-cluster-kubectl
-            - delete-cluster-custom-values-ssh
-            - delete-cluster-custom-values
-            - delete-cluster-defaults
-          context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      # - setup-cluster-with-ssh:
+      #     name: setup-cluster-custom-values-ssh
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+      #     context: [CPE_ORBS_AWS]
+      #     region: "us-west-2"
+      #     zones: "us-west-2b,us-west-2c"
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-installs-docker
+      #       - integration-test-installs-macos
+      #       - integration-test-installs-machine
+      # - test-cluster:
+      #     name: test-cluster-custom-values-ssh
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+      #     context: [CPE_ORBS_AWS]
+      #     executor: python
+      #     region: "us-west-2"
+      #     filters: *filters
+      #     requires:
+      #       - setup-cluster-custom-values-ssh
+      # - test-ssh-access:
+      #     name: test-ssh-access
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+      #     context: [CPE_ORBS_AWS]
+      #     region: "us-west-2"
+      #     release-name: grafana
+      #     add-repo: https://grafana.github.io/helm-charts
+      #     executor: python
+      #     filters: *filters
+      #     requires:
+      #       - test-cluster-custom-values-ssh
+      # - delete-cluster:
+      #     name: delete-cluster-custom-values-ssh
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-custom-values-ssh
+      #     context: [CPE_ORBS_AWS]
+      #     region: "us-west-2"
+      #     filters: *filters
+      #     wait: true
+      #     requires:
+      #       - test-ssh-access
+      #       - test-cluster-custom-values-ssh
+      # #Kubectl Tests
+      # - aws-eks/create-cluster:
+      #     name: setup-cluster-kubectl
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+      #     context: [CPE_ORBS_AWS]
+      #     aws-region: "us-west-2"
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-installs-docker
+      #       - integration-test-installs-macos
+      #       - integration-test-installs-machine
+      # - create-deployment:
+      #     name: create-deployment-kubectl
+      #     executor: python
+      #     context: [CPE_ORBS_AWS]
+      #     region: "us-west-2"
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+      #     filters: *filters
+      #     requires:
+      #       - setup-cluster-kubectl
+      # - aws-eks/update-container-image:
+      #     name: update-container-image-kubectl
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+      #     context: [CPE_ORBS_AWS]
+      #     aws-region: "us-west-2"
+      #     resource-name: "deployment/nginx-deployment"
+      #     container-image-updates: "nginx=nginx:1.9.1"
+      #     get-rollout-status: true
+      #     filters: *filters
+      #     post-steps:
+      #       - kubernetes/delete-resource:
+      #           resource-types: "deployments"
+      #           resource-names: "nginx-deployment"
+      #           now: true
+      #           wait: true
+      #     requires:
+      #       - create-deployment-kubectl
+      # - aws-eks/delete-cluster:
+      #     name: delete-cluster-kubectl
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-eks-orb-test-kubectl
+      #     context: [CPE_ORBS_AWS]
+      #     aws-region: "us-west-2"
+      #     wait: true
+      #     filters: *filters
+      #     requires:
+      #       - update-container-image-kubectl
+      # #Fargate Tests
+      # - setup-cluster-with-many-params:
+      #     name: setup-cluster-fargate
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
+      #     region: "us-west-2"
+      #     fargate: true
+      #     zones: "us-west-2a,us-west-2c"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-installs-docker
+      #       - integration-test-installs-macos
+      #       - integration-test-installs-machine
+      # - test-cluster:
+      #     name: test-cluster-fargate
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
+      #     context: [CPE_ORBS_AWS]
+      #     region: "us-west-2"
+      #     executor: python
+      #     filters: *filters
+      #     requires:
+      #       - setup-cluster-fargate
+      # - delete-cluster:
+      #     name: delete-cluster-fargate
+      #     cluster-name: ${AWS_RESOURCE_NAME_PREFIX}-orb-test-fargate
+      #     context: [CPE_ORBS_AWS]
+      #     region: "us-west-2"
+      #     wait: true
+      #     filters: *filters          
+      #     requires:
+      #       - test-cluster-fargate      
+      # - orb-tools/pack:
+      #     filters: *filters
+      # - orb-tools/publish:
+      #     orb-name: circleci/aws-eks
+      #     vcs-type: << pipeline.project.type >>
+      #     pub-type: production
+      #     requires:
+      #       - orb-tools/pack
+      #       - delete-cluster-fargate
+      #       - delete-cluster-kubectl
+      #       - delete-cluster-custom-values-ssh
+      #       - delete-cluster-custom-values
+      #       - delete-cluster-defaults
+      #     context: orb-publisher
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 executors:
   docker:
     docker:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,5 @@ display:
   home_url: https://aws.amazon.com/eks/
   source_url: https://github.com/CircleCI-Public/aws-eks-orb
 orbs:
-  aws-cli: circleci/aws-cli@2.0
   helm: circleci/helm@1.2
   kubernetes: circleci/kubernetes@1.0

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -67,11 +67,11 @@ parameters:
       Version of kubectl to install
     type: string
     default: "v1.22.0"
-  install-aws-cli:
-    description: |
-      Whether to install aws-cli
-    type: boolean
-    default: true
+  # install-aws-cli:
+  #   description: |
+  #     Whether to install aws-cli
+  #   type: boolean
+  #   default: true
 
 steps:
   - when:
@@ -81,10 +81,10 @@ steps:
             kubectl-version: << parameters.kubectl-version >>
   - install-aws-iam-authenticator:
       release-tag: << parameters.authenticator-release-tag >>
-  - when:
-      condition: << parameters.install-aws-cli >>
-      steps:
-        - aws-cli/setup
+  # - when:
+  #     condition: << parameters.install-aws-cli >>
+  #     steps:
+  #       - aws-cli/setup
   - run:
       environment:
         PARAM_CLUSTER_NAME: << parameters.cluster-name >>

--- a/src/commands/update-kubeconfig-with-authenticator.yml
+++ b/src/commands/update-kubeconfig-with-authenticator.yml
@@ -67,11 +67,6 @@ parameters:
       Version of kubectl to install
     type: string
     default: "v1.22.0"
-  # install-aws-cli:
-  #   description: |
-  #     Whether to install aws-cli
-  #   type: boolean
-  #   default: true
 
 steps:
   - when:
@@ -81,10 +76,6 @@ steps:
             kubectl-version: << parameters.kubectl-version >>
   - install-aws-iam-authenticator:
       release-tag: << parameters.authenticator-release-tag >>
-  # - when:
-  #     condition: << parameters.install-aws-cli >>
-  #     steps:
-  #       - aws-cli/setup
   - run:
       environment:
         PARAM_CLUSTER_NAME: << parameters.cluster-name >>

--- a/src/examples/create-eks-cluster.yml
+++ b/src/examples/create-eks-cluster.yml
@@ -1,17 +1,19 @@
 description: |
-  Create an eks cluster together with the required VPC-related
-  resources, test it, and tear it down.
+  Create an eks cluster together with the required VPC-related resources, test it, and tear it down using OIDC authentication.
+  Import the aws-cli orb and authenticate using the aws-cli/setup command with a valid role-arn for OIDC authentication.
 usage:
   version: 2.1
 
   orbs:
-    aws-eks: circleci/aws-eks@<<pipeline.parameters.dev-orb-version>>
+    aws-eks: circleci/aws-eks@3.0
     kubernetes: circleci/kubernetes@1.3
+    # Importing aws-cli orb is required
+    aws-cli: circleci/aws-cli@3.1
 
   jobs:
     test-cluster:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.11
       parameters:
         cluster-name:
           description: |
@@ -30,6 +32,15 @@ usage:
     deployment:
       jobs:
         - aws-eks/create-cluster:
+            auth:
+              # Add authentication step with OIDC using aws-cli/setup command
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_OIDC_ROLE"
+            # Must use same profile configured in aws-cli/setup command
+            aws-profile: "OIDC-USER"
+            # must use valid CircleCI context for OIDC authentication
+            context: "OIDC-CONTEXT"
             cluster-name: my-eks-demo
         - test-cluster:
             cluster-name: my-eks-demo
@@ -37,5 +48,14 @@ usage:
               - aws-eks/create-cluster
         - aws-eks/delete-cluster:
             cluster-name: my-eks-demo
+            auth:
+              # Add authentication step with OIDC using aws-cli/setup command
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_OIDC_ROLE"
+            # Must use same profile configured in aws-cli/setup command
+            aws-profile: "OIDC-USER"
+            # must use valid CircleCI context for OIDC authentication
+            context: "OIDC-CONTEXT"
             requires:
               - test-cluster

--- a/src/jobs/create-cluster.yml
+++ b/src/jobs/create-cluster.yml
@@ -77,8 +77,14 @@ parameters:
       Specifies which release-tag version of the authenticator to install.
     type: string
     default: ""
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 
 steps:
+  - steps: << parameters.auth >>
   - install-aws-iam-authenticator:
       release-tag: << parameters.authenticator-release-tag >>
   - create-cluster:

--- a/src/jobs/delete-cluster.yml
+++ b/src/jobs/delete-cluster.yml
@@ -63,8 +63,14 @@ parameters:
       The string is a decimal with unit suffix, such as “20m”, “1.25h”, “5s” (default: 20 minutes)
     type: string
     default: "30m"
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 
 steps:
+  - steps: << parameters.auth >>
   - update-kubeconfig-with-authenticator:
       cluster-name: << parameters.cluster-name >>
       aws-region: << parameters.aws-region >>

--- a/src/jobs/update-container-image.yml
+++ b/src/jobs/update-container-image.yml
@@ -89,8 +89,14 @@ parameters:
       Version of kubectl to install
     type: string
     default: "v1.22.0"
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 
 steps:
+  - steps: << parameters.auth >>
   - update-kubeconfig-with-authenticator:
       cluster-name: << parameters.cluster-name >>
       aws-region: << parameters.aws-region >>


### PR DESCRIPTION
This `PR` adds the `auth` parameter to all `eks` jobs, requiring users to customize their authentication method by importing the `aws-cli` orb and using the `aws-cli/setup` command to authenticate using static AWS keys or a valid `role-arn` for OIDC.