### PR TITLE
fix: update deprecated macos version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -605,7 +605,7 @@ executors:
       - image: cimg/base:current
   macos:
     macos:
-      xcode: 13.2.0
+      xcode: 14.2.0
   machine:
     machine:
       image: ubuntu-2004:202107-02


### PR DESCRIPTION
Currently, the `macos` tests use version `13.2.0`, which has been deprecated. 

This `PR` updates  `macos` executor to `14.2.0`.