### PR TITLE
Fix command names in docs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,10 +4,10 @@ A CircleCI Orb to simplify deployments to Amazon Elastic Container Service for K
 
 Here are some features that the AWS EKS orb provides:
 
-- Setting up and tearing down of EKS clusters via the `create-cluster` and `delete-cluster` commands / jobs
-- Allowing `kubectl` and other tools that access `kubeconfig` (like `helm`) to work with an EKS cluster via the `update-kubeconfig-with-authenticator` command
-- Updating deployments with container image updates via the `update-container-image` job
-- Installing helm and helm charts (See: `install-helm-on-cluster` and `install-helm-chart`)
+- Setting up and tearing down of EKS clusters via the `create_cluster` and `delete_cluster` commands / jobs
+- Allowing `kubectl` and other tools that access `kubeconfig` (like `helm`) to work with an EKS cluster via the `update_kubeconfig_with_authenticator` command
+- Updating deployments with container image updates via the `update_container_image` job
+- Installing helm and helm charts (See: `install_helm_on_cluster` and `install_helm_chart`)
 
 ## Usage
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -29,13 +29,13 @@ The `orb-publishing` context is referenced in the build. In particular, the foll
 
 ### AWS Resource Cleanup
 
-The tests configured in `.circleci/config.yml` have been tested to be able to successfully clean up the AWS resources used, via the `delete-cluster` command. 
+The tests configured in `.circleci/config.yml` have been tested to be able to successfully clean up the AWS resources used, via the `delete_cluster` command. 
 
-However, when adding new tests, depending on the type of AWS resources involved (e.g. AWS Elastic Load Balancers), you may encounter situations where if the resources deployed onto the EKS cluster are not deleted before running `delete-cluster`, `delete-cluster` may fail to remove all of the deployed AWS resources, e.g. the VPC.
+However, when adding new tests, depending on the type of AWS resources involved (e.g. AWS Elastic Load Balancers), you may encounter situations where if the resources deployed onto the EKS cluster are not deleted before running `delete_cluster`, `delete_cluster` may fail to remove all of the deployed AWS resources, e.g. the VPC.
 
 When that happens, in order to properly clean up the AWS resources, first try to delete the CloudFormation stacks (there are 2 for each deployed cluster - one that has `nodegroup` in its name and one that ends with the `-cluster` suffix) by deleting the nodegroup stack first and then the the other stack, for each cluster and region under test.
 
-If a CloudFormation stack cannot be deleted, check on the status of the CloudFormation stack corresponding to the EKS cluster used in the test. If the status is `DELETE_FAILED`, check the events for a hint of which AWS resources could not be deleted. Usually it is a Load Balancer that is preventing the VPC (that was created by `create-cluster`) from being deleted. Once that resource has been deleted, you should be able to delete the entire VPC from the `VPC` section of the AWS Console.
+If a CloudFormation stack cannot be deleted, check on the status of the CloudFormation stack corresponding to the EKS cluster used in the test. If the status is `DELETE_FAILED`, check the events for a hint of which AWS resources could not be deleted. Usually it is a Load Balancer that is preventing the VPC (that was created by `create_cluster`) from being deleted. Once that resource has been deleted, you should be able to delete the entire VPC from the `VPC` section of the AWS Console.
 
 ## Orb Publishing
 The orb is promoted into publishing by triggering the `production-orb-publishing` workflow. This workflow is meant to be manually triggered by tagging a `master` branch commit, after (manually) verifying that it has successfully completed the `integration-tests` workflow. The `production-orb-publishing` workflow will promote into production a dev orb that was published with a version that corresponds to the shortened SHA-1 hash of the tagged commit. The workflow has a manual approval step before it can proceed to promotion of the orb.


### PR DESCRIPTION


### Checklist


- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

There are some old command names in docs. This PR fixed those.

### Description

A separator in command is `_` now. Ref #78.