### PR TITLE
Install `aws-cli` automatically on `update_kubeconfig_with_authenticator`

### DIFF
--- a/src/commands/update_kubeconfig_with_authenticator.yml
+++ b/src/commands/update_kubeconfig_with_authenticator.yml
@@ -67,6 +67,11 @@ parameters:
       Version of kubectl to install
     type: string
     default: "v1.22.0"
+  install_aws_cli:
+    description: |
+      Whether to install aws-cli
+    type: boolean
+    default: true
 
 steps:
   - when:
@@ -76,6 +81,10 @@ steps:
             kubectl_version: << parameters.kubectl_version >>
   - install_aws_iam_authenticator:
       release_tag: << parameters.authenticator_release_tag >>
+  - when:
+      condition: << parameters.install_aws_cli >>
+      steps:
+        - aws-cli/setup
   - run:
       environment:
         AWS_EKS_STR_CLUSTER_NAME: << parameters.cluster_name >>


### PR DESCRIPTION
### Checklist


- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary


### Description

`update_kubeconfig_with_authenticator` uses `aws` command to update `kubeconfig`.
https://github.com/CircleCI-Public/aws-eks-orb/blob/f749034cacab617f383e2d328debedb676bd1ada/src/scripts/update_kubeconfig_with_authenticator.sh#L35C9-L35C15

Users didn't need set up `aws-cli` because `update_kubeconfig_with_authenticator` automatically installed it.

But, in v3.0.0, `update_kubeconfig_with_authenticator` haven't installed it and the `aws` command fails. This is caused by #75. https://github.com/CircleCI-Public/aws-eks-orb/pull/75/files#diff-5cd2124f07c0634e75fcf3dbb9e6b4ba3bcd44c900014a27031c16983cd249c6

I'm not sure why that PR removed the setting (just forgot to add `auth` parameter?), but `update_kubeconfig_with_authenticator` still uses `aws` command. So I think it's better to install it inside `update_kubeconfig_with_authenticator`.
