### PR TITLE
fix: use install_kubectl instead of install to avoid KOPS dependency

### DIFF
--- a/src/commands/update_kubeconfig_with_authenticator.yml
+++ b/src/commands/update_kubeconfig_with_authenticator.yml
@@ -72,7 +72,7 @@ steps:
   - when:
       condition: << parameters.install_kubectl >>
       steps:
-        - kubernetes/install:
+        - kubernetes/install_kubectl:
             kubectl_version: << parameters.kubectl_version >>
   - install_aws_iam_authenticator:
       release_tag: << parameters.authenticator_release_tag >>


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Solves intermittent failures in update_kubeconfig_with_authenticator command due to GitHub rate limiting when installing KOPS. The KOPS installation step is unnecessary for EKS cluster authentication and causes build failures.

Related Issues:

- https://github.com/CircleCI-Public/aws-eks-orb/issues/86
- https://github.com/CircleCI-Public/kubernetes-orb/issues/78

Root Cause: The kubernetes/install step installs both KOPS and kubectl, but KOPS is not required for this operation. The KOPS installation frequently fails due to GitHub's rate limiting, causing the entire command to fail.

### Description

Replace kubernetes/install with kubernetes/install_kubectl in the update_kubeconfig_with_authenticator command to eliminate the unnecessary KOPS dependency.
Maintains all existing functionality while removing KOPS installation.
