### PR TITLE
feat!: bump default kubectl version v1.22.0 → v1.36.1 (PIE-6)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,7 +42,7 @@ jobs:
             else
               version=<< parameters.release_tag >>
             fi
-            
+
             if aws-iam-authenticator version | grep -q "$version"; then
               echo "Version $version installed"
               exit 0
@@ -173,7 +173,7 @@ jobs:
     steps:
       - checkout
       - kubernetes/install:
-          kubectl_version: v1.22.0
+          kubectl_version: v1.36.1
       - browser-tools/install_chrome
       - browser-tools/install_chromedriver
       # Test various update-kubeconfig options
@@ -286,7 +286,7 @@ jobs:
           command: |
             aws-iam-authenticator
       - kubernetes/install:
-          kubectl_version: v1.22.0
+          kubectl_version: v1.36.1
       - run:
           name: Test with kubectl
           command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -172,7 +172,7 @@ jobs:
     executor: << parameters.executor >>
     steps:
       - checkout
-      - kubernetes/install:
+      - kubernetes/install_kubectl:
           kubectl_version: v1.36.1
       - browser-tools/install_chrome
       - browser-tools/install_chromedriver
@@ -285,7 +285,7 @@ jobs:
           name: Test aws-iam-authenticator
           command: |
             aws-iam-authenticator
-      - kubernetes/install:
+      - kubernetes/install_kubectl:
           kubectl_version: v1.36.1
       - run:
           name: Test with kubectl

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -568,7 +568,7 @@ workflows:
           context: [CPE-OIDC]
           aws_region: "us-west-2"
           resource_name: "deployment/nginx-deployment"
-          container_image_updates: "nginx=nginx:1.9.1"
+          container_image_updates: "nginx=nginx:1.29.3"
           get_rollout_status: true
           filters: *filters
           post-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -110,7 +110,7 @@ jobs:
           node_volume_size: 30
           node_volume_type: "gp2"
           max_pods_per_node: 30
-          node_ami_family: "AmazonLinux2"
+          node_ami_family: "AmazonLinux2023"
           node_private_networking: false
           node_labels: "nodeowner=cci,nodepurpose=testing"
           vpc_cidr: "192.168.0.0/16"

--- a/integration-tests/nginx-deployment/deployment.yaml
+++ b/integration-tests/nginx-deployment/deployment.yaml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: nginx
-  replicas: 2 # tells deployment to run 2 pods matching the template
+  replicas: 1
   template:
     metadata:
       labels:

--- a/integration-tests/nginx-deployment/deployment.yaml
+++ b/integration-tests/nginx-deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.30.2
         ports:
         - containerPort: 80

--- a/src/commands/create_cluster.yml
+++ b/src/commands/create_cluster.yml
@@ -226,7 +226,7 @@ steps:
   - unless:
       condition: << parameters.skip_kubectl_install >>
       steps:
-        - kubernetes/install:
+        - kubernetes/install_kubectl:
             kubectl_version: << parameters.kubectl_version >>
   - run:
       environment:

--- a/src/commands/create_cluster.yml
+++ b/src/commands/create_cluster.yml
@@ -203,7 +203,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "v1.22.0"
+    default: "v1.36.1"
   aws_max_polling_wait_time:
     description: |
       Max wait time in any AWS polling operations

--- a/src/commands/update_kubeconfig_with_authenticator.yml
+++ b/src/commands/update_kubeconfig_with_authenticator.yml
@@ -66,7 +66,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "v1.22.0"
+    default: "v1.36.1"
 
 steps:
   - when:

--- a/src/examples/create_eks_cluster.yml
+++ b/src/examples/create_eks_cluster.yml
@@ -21,7 +21,7 @@ usage:
           type: string
       steps:
         - kubernetes/install:
-            kubectl_version: v1.22.0
+            kubectl_version: v1.36.1
         - aws-eks/update_kubeconfig_with_authenticator:
             cluster_name: << parameters.cluster_name >>
         - run:

--- a/src/jobs/update_container_image.yml
+++ b/src/jobs/update_container_image.yml
@@ -88,7 +88,7 @@ parameters:
     description: |
       Version of kubectl to install
     type: string
-    default: "v1.22.0"
+    default: "v1.36.1"
   auth:
     description: |
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and

--- a/tests/nginx-deployment/deployment.yml
+++ b/tests/nginx-deployment/deployment.yml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: nginx
-  replicas: 2 # tells deployment to run 2 pods matching the template
+  replicas: 1
   template:
     metadata:
       labels:

--- a/tests/nginx-deployment/deployment.yml
+++ b/tests/nginx-deployment/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.30.2
         ports:
         - containerPort: 80


### PR DESCRIPTION
## Summary

- Bumps `kubectl_version` default in `commands/create_cluster.yml` and `commands/update_kubeconfig_with_authenticator.yml` from `v1.22.0` to `v1.36.1`
- Kubernetes v1.22.0 reached end-of-life in October 2022.

## Breaking change

Users who relied on the `v1.22.0` default without pinning an explicit `kubectl_version` will now get kubectl v1.36.1.

## Migration guide (v→v+1)

```yaml
# Pin the old version to keep it:
- aws-eks/create_cluster:
    kubectl_version: "v1.22.0"
```

Closes PIE-6