### PR TITLE
feat: add deploy markers integration to update_container_image job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -570,6 +570,8 @@ workflows:
           resource_name: "deployment/nginx-deployment"
           container_image_updates: "nginx=nginx:1.9.1"
           get_rollout_status: true
+          deploy_markers_mode: PLAN_AND_UPDATE
+          deploy_markers_deploy_name: test-deploy
           filters: *filters
           post-steps:
             - kubernetes/delete_resource:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,3 +8,4 @@ display:
 orbs:
   helm: circleci/helm@3.2.0
   kubernetes: circleci/kubernetes@2.0.0
+  deploys: circleci/deploys@1.0

--- a/src/examples/deploy_with_deploy_markers.yml
+++ b/src/examples/deploy_with_deploy_markers.yml
@@ -1,0 +1,56 @@
+description: >
+  Update a container image on EKS with CircleCI deploy markers.
+  Four modes are available via the deploy_markers_mode parameter:
+    OFF             - no deploy markers
+    LOG             - log a deployment event after the deploy
+    PLAN            - create a planned marker before the deploy; caller manages status updates
+    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed (default)
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-eks: circleci/aws-eks@3.0
+    # Importing aws-cli orb is required
+    aws-cli: circleci/aws-cli@5.4
+
+  workflows:
+    deploy:
+      jobs:
+        # LOG mode — log a deployment event after the deploy completes
+        - aws-eks/update_container_image:
+            name: deploy-log
+            cluster_name: my-eks-demo
+            resource_name: deployment/nginx-deployment
+            container_image_updates: "nginx=nginx:1.9.1"
+            aws_region: us-west-2
+            deploy_markers_mode: LOG
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        - aws-eks/update_container_image:
+            name: deploy-plan
+            cluster_name: my-eks-demo
+            resource_name: deployment/nginx-deployment
+            container_image_updates: "nginx=nginx:1.9.1"
+            aws_region: us-west-2
+            deploy_markers_mode: PLAN
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN_AND_UPDATE mode — full lifecycle managed by the orb (default)
+        - aws-eks/update_container_image:
+            name: deploy-full
+            cluster_name: my-eks-demo
+            resource_name: deployment/nginx-deployment
+            container_image_updates: "nginx=nginx:1.9.1"
+            aws_region: us-west-2
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}

--- a/src/jobs/update_container_image.yml
+++ b/src/jobs/update_container_image.yml
@@ -94,6 +94,34 @@ parameters:
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
     type: steps
+  deploy_markers_mode:
+    description: >
+      Controls CircleCI deploy marker integration via the deploys orb.
+      OFF: no deploy markers are created.
+      LOG: logs a deployment event after the deploy completes.
+      PLAN: creates a planned deployment marker before the deploy; status updates are left to the caller.
+      PLAN_AND_UPDATE: full lifecycle — plan before deploy, mark as running, then set SUCCESS or FAILED after (default).
+    type: enum
+    enum: [OFF, LOG, PLAN, PLAN_AND_UPDATE]
+    default: PLAN_AND_UPDATE
+  deploy_markers_deploy_name:
+    description: >
+      Unique identifier for this deployment within the workflow. Used by PLAN and PLAN_AND_UPDATE modes.
+      Must be unique if planning multiple deployments in the same workflow.
+    type: string
+    default: "deploy"
+  deploy_markers_namespace:
+    description: >
+      Namespace of the deployment shown in the CircleCI Deploys UI (distinct from the Kubernetes namespace).
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to 'default' if not set.
+    type: string
+    default: ""
+  deploy_markers_target_version:
+    description: >
+      Version identifier shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to the short commit SHA if not set.
+    type: string
+    default: ""
 
 steps:
   - steps: << parameters.auth >>
@@ -104,6 +132,26 @@ steps:
       install_kubectl: true
       authenticator_release_tag: << parameters.authenticator_release_tag >>
       kubectl_version: << parameters.kubectl_version >>
+  - when:
+      condition:
+        or:
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN"]
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/plan:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            component_name: << parameters.resource_name >>
+            environment_name: << parameters.cluster_name >>
+            namespace: << parameters.deploy_markers_namespace >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: RUNNING
+            when: always
   - kubernetes/update_container_image:
       resource_name: << parameters.resource_name >>
       container_image_updates: << parameters.container_image_updates >>
@@ -113,3 +161,24 @@ steps:
       pinned_revision_to_watch: << parameters.pinned_revision_to_watch >>
       watch_timeout: << parameters.watch_timeout >>
       show_kubectl_command: << parameters.show_kubectl_command >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "LOG"]
+      steps:
+        - deploys/log:
+            component_name: << parameters.resource_name >>
+            environment_name: << parameters.cluster_name >>
+            namespace: << parameters.deploy_markers_namespace >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: SUCCESS
+            when: on_success
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: FAILED
+            when: on_fail


### PR DESCRIPTION
## Summary

- Imports `circleci/deploys@1.0` orb in `src/@orb.yml`
- Adds `deploy_markers_mode` (OFF/LOG/PLAN/PLAN_AND_UPDATE, default `PLAN_AND_UPDATE`) plus `deploy_markers_deploy_name`, `deploy_markers_namespace`, and `deploy_markers_target_version` parameters to the `update_container_image` job — full lifecycle: plan before deploy, mark running, then SUCCESS or FAILED after
- Maps deploy marker fields to EKS concepts: `component_name` ← `resource_name`, `environment_name` ← `cluster_name`
- Adds example file `deploy_with_deploy_markers.yml` showing all active modes
- Adds `PLAN_AND_UPDATE` coverage to the existing `update_container_image-kubectl` integration test

All new parameters have defaults so existing configs require no changes.

Mirrors the same integration already added to [aws-ecs-orb #249](https://github.com/CircleCI-Public/aws-ecs-orb/pull/249) and [aws-elastic-beanstalk-orb #33](https://github.com/CircleCI-Public/aws-elastic-beanstalk-orb/pull/33).

## Test plan

- [x] `circleci orb pack src` + `circleci orb validate` pass
- [x] Verify existing jobs with no deploy marker params behave identically
- [x] Test `update_container_image` with `deploy_markers_mode: LOG`, `PLAN`, and `PLAN_AND_UPDATE`
- [x] Confirm deploy markers appear in the CircleCI Deploys UI for each mode (integration tests pass only in the CircleCI-Public org with OIDC role + contexts)

Tested with my own test app that has a deployment job to EKS cluster.
Here is the pipeline:
https://app.circleci.com/pipelines/circleci/H8yi9Wc3UrKUdM5DjTEpuX/24vo6j1sJa319zf4n81nkQ/12/workflows/b018e2db-36cf-4e3e-9d89-c20db63227de/jobs/17
<img width="1757" height="1264" alt="Screenshot 2026-06-15 at 4 21 42 PM" src="https://github.com/user-attachments/assets/5ec274a5-ebd1-4251-8f7e-e8fb21ed725a" />

<img width="1384" height="1253" alt="Screenshot 2026-06-15 at 4 22 14 PM" src="https://github.com/user-attachments/assets/7f3ec425-0d14-40d7-833c-d7ef28c45c91" />

Tested LOG, PLAN, OFF
<img width="2303" height="1261" alt="Screenshot 2026-06-15 at 4 41 35 PM" src="https://github.com/user-attachments/assets/44510717-14a4-49e0-bdc9-612f79fea6b4" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)